### PR TITLE
ci(fix): Add security-events permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   tests:
     permissions:
       contents: read # Needed to check out the repo.
+      security-events: write # Needed for zizmor to upload SARIF.
     uses: ./.github/workflows/pull_request.tests.yml
 
   # release


### PR DESCRIPTION
**Description:**

Add the `security-events: write` permission to allow zizmor to upload SARIF

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
